### PR TITLE
feat: update websocket docs about endpoints

### DIFF
--- a/api-reference/websocket/asyncapi.yaml
+++ b/api-reference/websocket/asyncapi.yaml
@@ -6,18 +6,25 @@ info:
     Real-time feeds for orderbooks and aggregated trades.
 
     ### Flow
-    1. Connect to `wss://api.ekiden.fi/ws`.
-    2. Send a **Subscribe** request on the root channel `/` with a channel name:
+    1. Choose environment:
+       - Production: `wss://api.ekiden.fi`
+       - Staging: `wss://api.staging.ekiden.fi`
+    2. Connect to `/ws/public` or `/ws/private` on the chosen host.
+    3. Send a **Subscribe** request on the root channel `/` with a channel name:
      - `orderbook/{market_addr}`
      - `trade/{market_addr}`
-    3. Receive **Subscribed**, then streaming events on the channel you subscribed to.
-    4. Use **Unsubscribe** or **Ping** when needed.
+    4. Receive **Subscribed**, then streaming events on the channel you subscribed to.
+    5. Use **Unsubscribe** or **Ping** when needed.
 
 servers:
   production:
     host: api.ekiden.fi
     protocol: wss
-    description: WebSocket endpoint
+    description: Production WebSocket endpoint
+  staging:
+    host: api.staging.ekiden.fi
+    protocol: wss
+    description: Staging WebSocket endpoint for testing
 
 channels:
   public:

--- a/api-reference/websocket/connect.mdx
+++ b/api-reference/websocket/connect.mdx
@@ -7,17 +7,25 @@ This page explains how to connect to Ekiden WebSocket streams, authenticate for 
 - Public stream: [AsyncAPI](../websockets/public) → channel `public`
 - Private stream: [AsyncAPI](../websockets/private) → channel `private`
 
-## Endpoints
+## Environments & Endpoints
 
-- Public: `wss://api.ekiden.fi/ws/public`
-- Private: `wss://api.ekiden.fi/ws/private`
+- Production
+    - REST: `https://api.ekiden.fi/api/v1`
+    - WS Public: `wss://api.ekiden.fi/ws/public`
+    - WS Private: `wss://api.ekiden.fi/ws/private`
+- Staging
+    - REST: `https://api.staging.ekiden.fi/api/v1`
+    - WS Public: `wss://api.staging.ekiden.fi/ws/public`
+    - WS Private: `wss://api.staging.ekiden.fi/ws/private`
+
+Choose your environment before connecting. Public feeds require no auth; private feeds require a bearer token from the matching REST environment.
 
 <Note>No authentication is required for the public stream. Private stream requires bearer token auth.</Note>
 
 ## Quick Start (JavaScript)
 
 ```javascript
-const ws = new WebSocket("wss://api.ekiden.fi/ws/public");
+const ws = new WebSocket("wss://api.ekiden.fi/ws/public"); // use staging URL for testing
 
 ws.onopen = () => {
     // Subscribe to orderbook and trades for a market
@@ -49,8 +57,8 @@ setInterval(() => {
 
 ## Private Stream Authentication
 
-1) Obtain a bearer token via the REST Authorize endpoint (JWT or similar).
-2) Connect to `wss://api.ekiden.fi/ws/private`.
+1) Obtain a bearer token via the REST Authorize endpoint (use the same environment as your WS connection).
+2) Connect to `wss://api.ekiden.fi/ws/private` (or staging equivalent).
 3) Send `AuthRequest` once connected.
 
 ```json


### PR DESCRIPTION
## Summary

* Update websocket docs (connect.mdx) to make it clearer to users that we have staging and production endpoints
* Update asyncapi.yaml to make it possible to change endpoints in playground