### PR TITLE
Fix docs program page routes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -163,6 +163,24 @@
       ]
     }
   },
+  "redirects": [
+    {
+      "source": "/Fees",
+      "destination": "/fees"
+    },
+    {
+      "source": "/VIP-program",
+      "destination": "/vip-program"
+    },
+    {
+      "source": "/Vip-program",
+      "destination": "/vip-program"
+    },
+    {
+      "source": "/Points-program",
+      "destination": "/points-program"
+    }
+  ],
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg"

--- a/fees.mdx
+++ b/fees.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fees"
+sidebarTitle: "Fees"
 description: "Ekiden is built for serious traders. Our fee structure is designed to reward both volume and liquidity. If you’re trading size or consistently making markets, you’ll benefit from lower costs and in many cases, get paid to provide liquidity.  Fees are calculated using a standard maker-taker model, with rates determined by your 30-day notional volume. Maker rebates kick in at higher tiers, and market share incentives offer additional rewards for dominating individual perp markets. All fee logic is transparent, predictable, and optimized for performance."
 ---
 

--- a/points-program.mdx
+++ b/points-program.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Points Program"
+sidebarTitle: "Points Program"
 description: "How Ekiden XP, referral points, and KOL campaign points should be earned and audited."
 ---
 

--- a/vip-program.mdx
+++ b/vip-program.mdx
@@ -1,5 +1,6 @@
 ---
 title: "VIP Program"
+sidebarTitle: "VIP Program"
 description: "Volume-based fee benefits and rewards for active Ekiden traders."
 ---
 


### PR DESCRIPTION
## Summary
- add redirects from legacy capitalized docs URLs to lowercase page routes
- set explicit sidebar titles for Fees, VIP Program, and Points Program

## Verification
- ran local docs.json route validation to confirm configured pages and redirect destinations resolve to files
- ran git diff --check

Note: Mintlify CLI verification could not complete locally because npm registry DNS was unavailable in the sandbox.