### PR TITLE
fix(openapi): make the document parse again, add the two missing enum schemas

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -16,7 +16,7 @@
     {
       "url": "https://api.canton.ekiden.fi/",
       "description": "Staging"
-    },
+    }
   ],
   "paths": {
     "/api/v1/account/balance": {
@@ -4163,6 +4163,14 @@
           "CreateByBboOrder"
         ]
       },
+      "Depth": {
+        "type": "string",
+        "enum": [
+          "10",
+          "50",
+          "200"
+        ]
+      },
       "ErrorResponse": {
         "type": "object",
         "required": [
@@ -5084,6 +5092,18 @@
           "3d",
           "1w",
           "1M"
+        ]
+      },
+      "IntervalTime": {
+        "type": "string",
+        "enum": [
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "4h",
+          "1d",
+          "4d"
         ]
       },
       "KlineSnapshot": {


### PR DESCRIPTION
`api-reference/openapi.json` does not parse. There is a trailing comma after the
Staging server entry on line 20, so any consumer that reads strict JSON stops on
the first token: client generators, validators, `json.load`. It came in through
the Mintlify web editor in 02d0545 (2025-08-21).

Three `$ref`s also point at schemas that are not defined in
`components.schemas`:

| Missing schema | Referenced by |
|---|---|
| `Depth` | `GET /api/v1/market/orderbook` (`depth`) |
| `IntervalTime` | `GET /api/v1/market/open-interest` (`interval`), `GET /api/v1/market/account-ratio` (`period`) |
| `OrderFilter` | `GET /api/v1/order/history`, `GET /api/v1/order/realtime` (`order_filter`) |

This PR fixes the parse error and adds `Depth` and `IntervalTime`, using the
values the gateway itself reports:

```
GET /api/v1/market/orderbook?symbol=CC-USDTx&depth=3
  depth: unknown variant `3`, expected one of `10`, `50`, `200`

GET /api/v1/market/open-interest?symbol=CC-USDTx&interval=zzz
  interval: unknown variant `zzz`, expected one of `5m`, `15m`, `30m`, `1h`, `4h`, `1d`, `4d`
```

Both are typed as string enums, matching the existing `Interval` schema.
"unknown variant" is serde's string-tagged enum error, which is why `Depth` is
`"10"` rather than `10` — happy to flip it if the Rust side says otherwise.

`OrderFilter` is deliberately left alone: those two routes are auth-gated, I
could not read its variants from outside, and a documented gap beats a guess.

After this change the document parses and `OrderFilter` is the only dangling
reference left.

Found while building an open-source Python market-data client against the
Canton testnet gateway.
